### PR TITLE
Question: when will you bring back the issue tab for this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,3 @@ This library also ships with a command line REPL to use the library. To use it:
 - Add your LIFX Developer API key to the .env file
 - Run `dart run bin/cli.dart`
 - Run `help` in the REPL to get a list of available commands.
-


### PR DESCRIPTION
I want to include this repo in my smart home open source project but since you removed the issue tab I am not sure that this is a good decision since there is no (usual) way to communicate with you about staff.

Do you have an estimation of when will you bring it back?.